### PR TITLE
Add ability to retrieve schema fields.  Update to solrj 5.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ test-files/dist
 .idea/
 .lein*
 target/
-*.iml
+*.iml*~

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject cc.artifice/clojure-solr "0.9.1"
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.apache.solr/solr-solrj "4.10.4"]
-                 [org.apache.solr/solr-core "4.10.4" :exclusions [commons-fileupload]]
+(defproject cc.artifice/clojure-solr "1.0.0"
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.apache.solr/solr-solrj "5.3.1"]
+                 [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]
                  [commons-fileupload "1.3"]
                  [org.slf4j/slf4j-jcl "1.7.6"]
-                 [clj-time "0.9.0"]]
+                 [clj-time "0.11.0" :exclusions [org.clojure/clojure]]]
   :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]]}}
   ;;:repositories [["restlet" {:url "http://maven.restlet.org"}]]
   :repositories [["restlet" {:url "http://repository.sonatype.org/content/groups/forge"}]]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -154,7 +154,7 @@
     (doseq [[key value] (dissoc flags :method :facet-fields :facet-date-ranges :facet-numeric-ranges :facet-filters)]
       (.setParam query (apply str (rest (str key))) (make-param value)))
     (when (not (empty? fields))
-      (.setFields query (into-array fields)))
+      (.setFields query (into-array (map name fields))))
     (.addFacetField query (into-array String (map name facet-fields)))
     (doseq [{:keys [field start end gap others include hardend]} facet-date-ranges]
       (.addDateRangeFacet query field start end gap)

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -3,7 +3,7 @@
   (:require [clj-time.core :as t])
   (:require [clj-time.format :as tformat])
   (:require [clj-time.coerce :as tcoerce])
-  (:import (org.apache.solr.client.solrj.impl HttpSolrServer)
+  (:import (org.apache.solr.client.solrj.impl HttpSolrClient)
            (org.apache.solr.common SolrInputDocument)
            (org.apache.solr.client.solrj SolrQuery SolrRequest$METHOD)
            (org.apache.solr.common.params ModifiableSolrParams)
@@ -12,7 +12,7 @@
 (declare ^:dynamic *connection*)
 
 (defn connect [url]
-  (HttpSolrServer. url))
+  (HttpSolrClient. url))
 
 (defn- make-document [boost-map doc]
   (let [sdoc (SolrInputDocument.)]

--- a/src/clojure_solr/schema.clj
+++ b/src/clojure_solr/schema.clj
@@ -1,0 +1,21 @@
+(ns clojure-solr.schema
+  (:require [clojure.string :as str])
+  (:import (org.apache.solr.client.solrj.impl HttpSolrClient)
+           (org.apache.solr.client.solrj.request.schema SchemaRequest$Fields)
+           (org.apache.solr.client.solrj.response.schema SchemaResponse$FieldsResponse)
+           (org.apache.solr.common SolrInputDocument)
+           (org.apache.solr.client.solrj SolrQuery SolrRequest$METHOD)
+           (org.apache.solr.common.params ModifiableSolrParams)
+           (org.apache.solr.util DateMathParser))
+  (:require [clojure-solr :as solr]))
+
+
+(defn get-schema-fields
+  []
+  (let [generic-response (.request solr/*connection* (SchemaRequest$Fields.))
+        fields-response (SchemaResponse$FieldsResponse.)]
+    (.setResponse fields-response generic-response)
+    (map (fn [field-schema]
+           (into {} (map (fn [[k v]] [(keyword k) v]) field-schema)))
+         (.getFields fields-response))))
+


### PR DESCRIPTION
Josh,

Since I'm pushing docs to solr now, I need to ensure that there's no metadata that's not an undefined field in solr... (for now... we could be really smart and use dynamic fields for unknown metadata, but it's not a highest priority.)

I added a schema sub-namespace with a function to get the defined (static) fields.  To fetch schema, I needed to upgrade to solrj 5.3.1, which coincidentally is the first version of the client that has schema support, AFAIK.  This created a wealth of problems related to newer versions of jetty. The easiest fix appears to be to move all of our jetty based containers to compojure 1.4.0 and/or ring 1.4.0, the latter of which brings in the newest jetty.  i2kweb was back on ring 1.3.2, whereas i2kconduit was already at 1.4.0.  (workers and source are at 1.3.4.)

I've got some local changes that I'll hold off pushing, for i2kweb project.clj, to exclude inconsistent library versions, until you've pulled and deployed this.

Thanks,
Eric
