### PR TITLE
Support for incremental faceting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.0.4"
+(defproject cc.artifice/clojure-solr "1.1.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]


### PR DESCRIPTION
Can pass a map as an element of the `facet-fields` parameter, or a string as currently supported.  If a map, must have a `:name`.  If it has a :prefix, then the query gets an `f.<<field>>.facet.prefix` parameter.  

Can pass a `:result-formatter` in the `facet-filters` parameter.  The formatter is a unary function that is passed an individual facet value map (the one containing name, value, depth, split-path) and can return a modified facet value map.  If no `:result-formatter`, `identity` is used.

If `solr/search` is called without a :`facet-hier-sep` parameter, search will no longer throw a null pointer exception, and will not calculate split-path, depth, etc. for facets.