### PR TITLE
FInish the faceting work: Fix error when not pivoting, update docs, add facet-queries.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.1.0"
+(defproject cc.artifice/clojure-solr "1.2.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.3.0"
+(defproject cc.artifice/clojure-solr "1.4.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.2.0"
+(defproject cc.artifice/clojure-solr "1.3.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -136,3 +136,29 @@
            (first (filter #(= (:name %) "updated") (:facet-range-fields result)))))))
 
 
+(deftest test-pivot-faceting
+  (add-document! sample-doc)
+  (add-document! (assoc sample-doc :id 2 :type "docx"))
+  (commit!)
+  (let [result (meta (search "my"
+                             :rows 0
+                             :facet-date-ranges
+                             [{:field    "updated"
+                               :tag      "ts"
+                               :start    (tcoerce/to-date (t/from-time-zone (t/date-time 2015 02 26)
+                                                                            (t/time-zone-for-id "America/Chicago")))
+                               :end      (tcoerce/to-date (t/from-time-zone (t/date-time 2015 02 28)
+                                                                            (t/time-zone-for-id "America/Chicago")))
+                               :gap      "+1DAY"
+                               :timezone (t/time-zone-for-id "America/Chicago")
+                               :others   ["before" "after"]}]
+                             :facet-pivot-fields ["{!range=ts}type"]))
+        pivot-fields (:facet-pivot-fields result)]
+    (is (= 1 (count pivot-fields)))
+    (is (get pivot-fields "type"))
+    (is (= 2 (count (get pivot-fields "type"))))
+    (is (= 1 (count (get-in pivot-fields ["type" "docx" "updated"]))))
+    (is (= 1 (:count (first (get-in pivot-fields ["type" "docx" "updated"])))))
+    (is (= 1 (count (get-in pivot-fields ["type" "pdf" "updated"]))))
+    (is (= 1 (:count (first (get-in pivot-fields ["type" "pdf" "updated"])))))
+    #_(clojure.pprint/pprint (:facet-pivot-fields result))))

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -52,6 +52,12 @@
          (:facet-fields
            (meta (search "my" :facet-fields [:terms] :facet-hier-sep #"/"))))))
 
+(deftest test-facet-query
+  (do (add-document! sample-doc)
+      (commit!))
+  (is (= [{:name "terms" :value "Vocabulary 1" :count 1}]
+         (:facet-queries (meta (search "my" :facet-queries [{:name "terms" :value "Vocabulary 1"}]))))))
+
 (deftest test-facet-prefix
   (do (add-document! sample-doc)
       (add-document! (assoc sample-doc :id "2" :numeric 11))


### PR DESCRIPTION
Version 1.4 adds the ability to return a formatted version of .getFacetQuery from the QueryResponse.  I found this necessary to get the count of docs in the root of a taxonomy when querying taxnodes and taxnodesf (but not depth-taxnodes).