### PR TITLE
Allow facet filter in which :value is not a string

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.5.0"
+(defproject cc.artifice/clojure-solr "1.5.1"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -103,7 +103,7 @@
 
 (defn format-facet-query
   [{:keys [name value formatter]}]
-  (if (re-find #"\[" value) ;; range filter
+  (if (and (string? value) (re-find #"\[" value)) ;; range filter
     (format-standard-filter-query name value)
     (if formatter
       (formatter name value)


### PR DESCRIPTION
For various reasons, it's convenient to pass a sequence of values in the :value field of a facet filter, relying upon the :formatter to make the proper Solr syntax.  There was code in format-facet-query that expected :value to be a string.
