### PR TITLE
Close the HttpSolrConnection upon exiting with-connection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.5.1"
+(defproject cc.artifice/clojure-solr "1.5.2"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.5.2"
+(defproject cc.artifice/clojure-solr "1.5.3"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -255,7 +255,8 @@
       (cond (string? facet-query)
             (.addFacetQuery query facet-query)
             (map? facet-query)
-            (.addFacetQuery query (format-facet-query facet-query))
+            (let [formatted-query (format-facet-query facet-query)]
+              (when (not-empty formatted-query) (.addFacetQuery query formatted-query)))
             :else (throw (Exception. "Invalid facet query.  Must be a string or a map of {:name, :value, :formatter (optional)}"))))
     (doseq [{:keys [field start end gap others include hardend missing mincount tag]} facet-date-ranges]
       (if tag
@@ -292,7 +293,7 @@
       (when hardend (.setParam query (format "f.%s.facet.range.hardend" field) hardend)))
     (doseq [field facet-pivot-fields]
       (.addFacetPivotField query (into-array String [field])))
-    (.addFilterQuery query (into-array String (map format-facet-query facet-filters)))
+    (.addFilterQuery query (into-array String (filter not-empty (map format-facet-query facet-filters))))
     (.setFacetMinCount query (or facet-mincount 1))
     (let [query-results (.query *connection* query method)
           results (.getResults query-results)]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -335,4 +335,6 @@
 
 (defmacro with-connection [conn & body]
   `(binding [*connection* ~conn]
-     ~@body))
+     (try
+       (do ~@body)
+       (finally (.close *connection*)))))


### PR DESCRIPTION
Failing to close the connection was causing (perhaps innocuous) error messages in Solr about the previous connection not being closed.