### PR TITLE
Implement support for basic authentication

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.5.8"
+(defproject cc.artifice/clojure-solr "1.6.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.5.7"
+(defproject cc.artifice/clojure-solr "1.5.8"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -191,23 +191,43 @@
   [query-results facet-date-ranges]
   (let [facet-pivot (.getFacetPivot query-results)]
     (when facet-pivot
-      (into
-       {}
-       (map
-        (fn [index]
-          (let [facet1-name (.getName facet-pivot index)
-                pivot-fields (.getVal facet-pivot index)
-                ranges (into {}
-                             (for [pivot-field pivot-fields]
-                               (let [facet1-value (.getValue pivot-field)
-                                     facet-ranges (extract-facet-ranges pivot-field facet-date-ranges)]
-                                 [facet1-value
-                                  (into {}
-                                        (map (fn [range]
-                                               [(:name range) (:values range)])
-                                             facet-ranges))])))]
-            [facet1-name ranges]))
-        (range 0 (.size facet-pivot)))))))
+      (merge
+       (into
+        {}
+        (map
+         (fn [index]
+           (let [facet1-name (.getName facet-pivot index)
+                 pivot-fields (.getVal facet-pivot index)
+                 ranges (into {}
+                              (for [pivot-field pivot-fields]
+                                (let [facet1-value (.getValue pivot-field)
+                                      facet-ranges (extract-facet-ranges pivot-field facet-date-ranges)]
+                                  [facet1-value
+                                   (into {}
+                                         (map (fn [range]
+                                                [(:name range) (:values range)])
+                                              facet-ranges))])))]
+             [facet1-name ranges]))
+         (range 0 (.size facet-pivot))))
+       (into
+        {}
+        (map
+         (fn [index]
+           (let [facet1-name (.getName facet-pivot index)
+                 pivot-fields (.getVal facet-pivot index)
+                 pivots (into {}
+                              (for [pivot-field pivot-fields]
+                                (let [facet1-value (.getValue pivot-field)
+                                      pivot-values (.getPivot pivot-field)]
+                                  [facet1-value
+                                   (into {}
+                                         (map (fn [pivot]
+                                                [(.getValue pivot) (.getCount pivot)])
+                                              pivot-values))])))]
+             (println facet1-name)
+             [facet1-name pivots]))
+         (range 0 (.size facet-pivot))))
+       ))))
 
 (defn show-query
   [q flags]

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -116,12 +116,12 @@
     (is (= {:name "numeric",
             :values
             [{:count 1,
-              :value "[* TO 9]",
+              :value "[* TO 9}",
               :min-inclusive nil,
               :max-noninclusive "9"}
              {:max-noninclusive "12",
               :min-inclusive "9",
-              :value "[9 TO 12]",
+              :value "[9 TO 12}",
               :count 3}
              {:count 1,
               :value "[12 TO *]",


### PR DESCRIPTION
SolrJ expects one to use basic authentication by setting the basic auth parameters in each request to Solr.  However, clojure-solr uses convenience methods on the HttpSolrClient that never expose the SolrXXXRequest to the Clojure layer, so it's not straightforward to provision the authorization header in requests.  The alternative, implemented here, is to manage a credentials provider and configure an HttpRequestInterceptor to set up the authstate for each request.

To use Solr with basic auth, pass the Solr URL in the standard form containing a username and password: 

```https://user:password@server.host.name/solr/core```

User credentials are cached privately within clojure-solr, so that the Solr URL doesn't have to be dissected on each call to `(clojure-solr/with-connection ...)`

This should work when Solr is responsible for basic authentication, and has been demonstrated to work when Apache manages basic auth and proxies to a local Solr that's otherwise inaccessible.
