### PR TITLE
Atomic updates and search result cursors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.6.0"
+(defproject cc.artifice/clojure-solr "1.7.0"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.7.0"
+(defproject cc.artifice/clojure-solr "1.7.1"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -13,6 +13,7 @@
            (org.apache.http.impl.client BasicCredentialsProvider HttpClientBuilder)
            (org.apache.http.protocol HttpContext HttpCoreContext)
            (org.apache.solr.client.solrj.impl HttpSolrClient HttpClientUtil)
+           (org.apache.solr.client.solrj.embedded EmbeddedSolrServer)
            (org.apache.solr.common SolrInputDocument)
            (org.apache.solr.client.solrj SolrQuery SolrRequest$METHOD)
            (org.apache.solr.common.params ModifiableSolrParams)
@@ -513,6 +514,5 @@
   `(binding [*connection* ~conn]
      (try
        (do ~@body)
-       (finally (.close (.getHttpClient *connection*))
-                (.close *connection*)))))
+       (finally (.close *connection*)))))
 

--- a/test-files/core/conf/schema.xml
+++ b/test-files/core/conf/schema.xml
@@ -75,6 +75,7 @@
          lexicographic ordering isn't equal to the numeric ordering) -->
     <fieldType name="integer" class="solr.TrieIntField" omitNorms="true"/>
     <fieldType name="long" class="solr.TrieLongField" omitNorms="true"/>
+    <fieldType name="slong" class="solr.TrieLongField" omitNorms="true" sortMissingLast="true"/>
     <fieldType name="float" class="solr.TrieFloatField" omitNorms="true"/>
     <fieldType name="double" class="solr.TrieDoubleField" omitNorms="true"/>
 
@@ -258,6 +259,7 @@
    -->
 
    <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" omitNorms="true" /> 
+   <field name="_version_" type="slong" default="0" docValues="true" multiValued="false" indexed="true" stored="true"/>
    <field name="title" type="text" indexed="true" stored="true" />
    <field name="fulltext" type="text" indexed="true" stored="true" />
    <field name="created" type="date" indexed="true" stored="true" omitNorms="true" />

--- a/test-files/core/conf/solrconfig.xml
+++ b/test-files/core/conf/solrconfig.xml
@@ -34,6 +34,9 @@
   <!-- the default high-performance update handler -->
   <updateHandler class="solr.DirectUpdateHandler2">
 
+    <updateLog>
+      <str name="dir">${solr.core.dataDir}/log</str>
+    </updateLog>
     <!-- A prefix of "solr." for class names is an alias that
          causes solr to search appropriate packages, including
          org.apache.solr.(search|update|request|core|analysis)

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -52,6 +52,15 @@
          (:facet-fields
            (meta (search "my" :facet-fields [:terms] :facet-hier-sep #"/"))))))
 
+(deftest test-update-document!
+  (do (add-document! sample-doc)
+      (commit!))
+  (atomically-update! 1 :id [{:attribute :title :func :set :value "my new title"}])
+  (commit!)
+  (let [search-result (search "my")]
+    (is (= (get (first search-result) :title) "my new title"))))
+  
+
 (deftest test-quoted-search
   (do (add-document! sample-doc)
       (commit!))


### PR DESCRIPTION
Includes the ability to perform an atomic update on fields of a document (add, set, inc)

Includes the ability to iterate over search results using a cursor mark.

