### PR TITLE
Support faceting the same field multiple ways (e.g., multiple prefix filters)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cc.artifice/clojure-solr "1.8.0"
+(defproject cc.artifice/clojure-solr "1.8.1"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.solr/solr-solrj "5.3.1"]
                  [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -144,19 +144,21 @@
 (defn extract-facets
   [query-results facet-hier-sep limiting? formatters key-fields]
   (map (fn [^FacetField f]
-         {:name (get key-fields (.getName f) (.getName f))
-          :values (sort-by :path
-                           (map (fn [v]
-                                  (let [result
-                                        (merge
-                                         {:value (.getName v)
-                                          :count (.getCount v)}
-                                         (when-let [split-path (and facet-hier-sep (str/split (.getName v) facet-hier-sep))]
-                                           {:split-path split-path
-                                            :title (last split-path)
-                                            :depth (count split-path)}))]
-                                    ((get formatters (.getName f) identity) result)))
-                                (.getValues f)))})
+         (let [field-name (.getName f)
+               facet-name (get key-fields field-name field-name)]
+           {:name facet-name
+            :values (sort-by :path
+                             (map (fn [v]
+                                    (let [result
+                                          (merge
+                                           {:value (.getName v)
+                                            :count (.getCount v)}
+                                           (when-let [split-path (and facet-hier-sep (str/split (.getName v) facet-hier-sep))]
+                                             {:split-path split-path
+                                              :title (last split-path)
+                                              :depth (count split-path)}))]
+                                      ((get formatters facet-name identity) result)))
+                                  (.getValues f)))}))
        ^List (if limiting?
                (.getLimitingFacets query-results)
                (.getFacetFields query-results))))

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -94,7 +94,7 @@
                                              :result-formatter #(update-in % [:value] clojure.string/lower-case)}]))]
     (is (not (empty? (:facet-fields result))))
     (is (= 3 (count (-> result :facet-fields first :values))))
-    (is (every? #(.startsWith (:value %) "vocabulary 1")
+    (is (every? #(.startsWith (:value %) "Vocabulary 1")
                 (-> result :facet-fields first :values)))))
 
 (deftest test-facet-ranges

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -94,7 +94,7 @@
                                              :result-formatter #(update-in % [:value] clojure.string/lower-case)}]))]
     (is (not (empty? (:facet-fields result))))
     (is (= 3 (count (-> result :facet-fields first :values))))
-    (is (every? #(.startsWith (:value %) "Vocabulary 1")
+    (is (every? #(.startsWith (:value %) "vocabulary 1")
                 (-> result :facet-fields first :values)))))
 
 (deftest test-facet-ranges


### PR DESCRIPTION
Faceting now uses Solr local params syntax to construct uniquely named facet requests.  This allows the same search request to facet the same field with two different prefixes.