### PR TITLE
Update internal dependencies to solr 6.6.4 client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject cc.artifice/clojure-solr "2.0.1"
+(defproject cc.artifice/clojure-solr "2.0.2"
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.solr/solr-solrj "6.6.4"]
-                 [org.apache.solr/solr-core "6.6.4" :exclusions [commons-fileupload]]
+                 [org.apache.solr/solr-solrj "6.6.6"]
+                 [org.apache.solr/solr-core "6.6.6" :exclusions [commons-fileupload]]
                  [commons-fileupload "1.3.1"]
                  ;;[org.slf4j/slf4j-jcl "1.7.6"]
                  [clj-time "0.11.0" :exclusions [org.clojure/clojure]]]

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject cc.artifice/clojure-solr "2.0.0"
+(defproject cc.artifice/clojure-solr "2.0.1"
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.solr/solr-solrj "5.3.1"]
-                 [org.apache.solr/solr-core "5.3.1" :exclusions [commons-fileupload]]
-                 [commons-fileupload "1.3"]
-                 [org.slf4j/slf4j-jcl "1.7.6"]
+                 [org.apache.solr/solr-solrj "6.6.4"]
+                 [org.apache.solr/solr-core "6.6.4" :exclusions [commons-fileupload]]
+                 [commons-fileupload "1.3.1"]
+                 ;;[org.slf4j/slf4j-jcl "1.7.6"]
                  [clj-time "0.11.0" :exclusions [org.clojure/clojure]]]
   :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]]}}
   ;;:repositories [["restlet" {:url "http://maven.restlet.org"}]]

--- a/src/clojure_solr.clj
+++ b/src/clojure_solr.clj
@@ -100,7 +100,7 @@
     (HttpSolrClient. clean-url client)))
 
 (defn- make-document [boost-map doc]
-  (let [sdoc (SolrInputDocument.)]
+  (let [sdoc (SolrInputDocument. (make-array String 0))]
     (doseq [[key value] doc]
       (let [key-string (name key)
             boost (get boost-map key)]
@@ -355,6 +355,11 @@
     (doseq [ff (:facet-fields flags)]
       (trace (format "    %s" (if (map? ff) (pr-str ff) ff))))
     (trace "    none"))
+  (trace "  Facet Numeric Ranges")
+  (if (not-empty (:facet-numeric-ranges flags))
+    (doseq [ff (:facet-numeric-ranges flags)]
+      (trace (format "    start: %s gap: %s end: %s" (:start ff) (:gap ff) (:end ff))))
+    (trace "    none"))
   (let [other (dissoc flags :facet-filters :facet-qieries :facet-fields)]
     (when (not-empty other)
       (trace "  Other parameters to Solr:")
@@ -597,7 +602,7 @@
    e.g.
      (atomically-update! doc \"cdid\" [{:attribute :client :func :set :value \"darcy\"}])"
   [doc unique-key-field changes]
-  (let [document (SolrInputDocument.)]
+  (let [document (SolrInputDocument. (make-array String 0))]
     (.addField document (name unique-key-field) (if (map? doc) (get doc unique-key-field) doc))
     (doseq [{:keys [attribute func value]} changes]
       (.addField document (name attribute) (doto (HashMap. 1) (.put (name func) value))))

--- a/test-files/core/conf/solrconfig.xml
+++ b/test-files/core/conf/solrconfig.xml
@@ -406,7 +406,7 @@
     </lst>
   </requestHandler>
   -->
-  <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
+  <!-- <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" /> -->
   
   <!-- ping/healthcheck -->
   <requestHandler name="/admin/ping" class="solr.PingRequestHandler">

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -201,14 +201,19 @@
   (add-document! (assoc sample-doc :id 2 :fulltext "This is a clinical study."))
   (add-document! (assoc sample-doc :id 3 :fulltext "This is a clinical trial and a clinical study."))
   (commit!)
-  (let [ct (search* "\"clinical trial\"" {:qf "fulltext" :defType "edismax" :fl "id" :mm "2<-25%"})
-        cs (search* "\"clinical study\"" {:qf "fulltext" :defType "edismax" :fl "id" :mm "2<-25%"})
-        cts (search* "\"clinical trial\" OR \"clinical study\"" {:qf "fulltext" :defType "edismax" :fl "id" :mm "2<-25%"})]
+  (let [ct (search* "\"clinical trial\"" {:df "fulltext" :defType "edismax" :fl "id"})
+        cs (search* "\"clinical study\"" {:df "fulltext" :defType "edismax" :fl "id"})
+        cts (search* "(\"clinical trial\" OR \"clinical study\")" {:df "fulltext" :defType "edismax" :fl "id" })
+        cts-plus (search* "+(\"clinical trial\" OR \"clinical study\")" {:df "fulltext" :defType "edismax" :fl "id" })
+        cts3 (search* "+(\"clinical trial\" OR \"clinical study\" OR \"foo baz\")" {:df "fulltext" :defType "edismax" :fl "id"})
+        ]
     (is (= 2 (count ct)))
     (is (= #{"1" "3"} (set (map :id ct))))
     (is (= 2 (count cs)))
     (is (= #{"2" "3"} (set (map :id cs))))
-    (is (= 1 (count cts)))
-    (is (= "3" (:id (first cts))))))
+    (is (= 3 (count cts)))
+    (is (= 3 (count cts-plus)))
+    (is (= 3 (count cts3)))
+    ))
         
   

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -27,7 +27,7 @@
     (.load cont)
     (binding [*connection* (EmbeddedSolrServer. cont "clojure-solr")]
       (f)
-      (.shutdown *connection*))))
+      (.close *connection*))))
 
 (use-fixtures :each solr-server-fixture)
 

--- a/test/clojure_solr_test.clj
+++ b/test/clojure_solr_test.clj
@@ -195,3 +195,20 @@
     (is (not-empty fields))
     (is (map? (get fields "fulltext")))
     (is (set? (get-in fields ["fulltext" :schema])))))
+
+(deftest test-edismax-disjunction
+  (add-document! (assoc sample-doc :id 1 :fulltext "This is a clinical trial."))
+  (add-document! (assoc sample-doc :id 2 :fulltext "This is a clinical study."))
+  (add-document! (assoc sample-doc :id 3 :fulltext "This is a clinical trial and a clinical study."))
+  (commit!)
+  (let [ct (search* "\"clinical trial\"" {:qf "fulltext" :defType "edismax" :fl "id" :mm "2<-25%"})
+        cs (search* "\"clinical study\"" {:qf "fulltext" :defType "edismax" :fl "id" :mm "2<-25%"})
+        cts (search* "\"clinical trial\" OR \"clinical study\"" {:qf "fulltext" :defType "edismax" :fl "id" :mm "2<-25%"})]
+    (is (= 2 (count ct)))
+    (is (= #{"1" "3"} (set (map :id ct))))
+    (is (= 2 (count cs)))
+    (is (= #{"2" "3"} (set (map :id cs))))
+    (is (= 1 (count cts)))
+    (is (= "3" (:id (first cts))))))
+        
+  


### PR DESCRIPTION
To remove known security vulnerabilities with solrj 5.3.1, this updates to the Java dependencies to solrj 6.6.4.